### PR TITLE
Change module path to jewzaam's account

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mjudeikis/go-cosmosdb
+module github.com/jewzaam/go-cosmosdb
 
 go 1.14
 


### PR DESCRIPTION
Fixes
```
  go: github.com/jewzaam/go-cosmosdb@${VERSION}
  parsing go.mod:
          module declares its path as: github.com/mjudeikis/go-cosmosdb
                  but was required as: github.com/jewzaam/go-cosmosdb
```