### PR TITLE
Add basic changefeed

### DIFF
--- a/example/cosmosdb/zz_generated_person_fake.go
+++ b/example/cosmosdb/zz_generated_person_fake.go
@@ -242,7 +242,9 @@ func (c *FakePersonClient) Delete(ctx context.Context, partitionKey string, pers
 	return nil
 }
 
-// ChangeFeed is unimplemented
+// ChangeFeed is a basic implementation of cosmosDB Changefeeds. Compared to the real changefeeds, its implementation is much more simplistic:
+// - Deleting a Person does not remove it from the existing change feeds
+// - when a Person is pushed into the changefeed, older versions that have not been retrieved won't be removed, meaning there's no guarantee that a person from the changefeed is actually the most recent version.
 func (c *FakePersonClient) ChangeFeed(*Options) PersonIterator {
 	c.lock.RLock()
 	defer c.lock.RUnlock()
@@ -266,10 +268,10 @@ func (c *FakePersonClient) updateChangeFeeds(person *pkg.Person) error {
 		if err != nil {
 			return err
 		}
+
 		currentIterator.people = append(currentIterator.people, newTpl)
 		currentIterator.done = false
 	}
-
 	return nil
 }
 
@@ -345,7 +347,7 @@ func (i *fakePersonIterator) Next(ctx context.Context, maxItemCount int) (*pkg.P
 			max = len(i.people)
 		}
 		people = i.people[i.continuation:max]
-		i.continuation += max
+		i.continuation = max
 		i.done = i.Continuation() == ""
 	}
 

--- a/pkg/gencosmosdb/cosmosdb/template_fake.go
+++ b/pkg/gencosmosdb/cosmosdb/template_fake.go
@@ -345,7 +345,7 @@ func (i *fakeTemplateIterator) Next(ctx context.Context, maxItemCount int) (*pkg
 			max = len(i.templates)
 		}
 		templates = i.templates[i.continuation:max]
-		i.continuation += max
+		i.continuation = max
 		i.done = i.Continuation() == ""
 	}
 


### PR DESCRIPTION
Adding a basic implementation of CosmosDB's ChangeFeed. This implementation only adds new elementes to the changefeed but it doesn't add deletions, and newer versions of objects are not guaranteed.

This will be used in the initial unit test implementation for Monitor in https://github.com/Azure/ARO-RP/pull/4380

We are not planning to add more functionalities to changefeed at this stage. 